### PR TITLE
Add support for links_to_entry query parameter

### DIFF
--- a/lib/contentful/query.ex
+++ b/lib/contentful/query.ex
@@ -157,6 +157,26 @@ defmodule Contentful.Query do
   end
 
   @doc """
+  adds the `links_to_entry` parameter to a query, allowing to filter entries by the entries they link to.
+
+  ## Example
+      alias Contentful.Delivery.Entries
+      Entries |> links_to_entry("foobar") |> fetch_all
+  """
+  @spec links_to_entry({Entries, list()}, String.t()) :: {Entries, list()}
+  def links_to_entry({Entries, parameters}, entry_id) do
+    {Entries, parameters |> Keyword.put(:links_to_entry, entry_id)}
+  end
+
+  def links_to_entry(Entries, entry_id) do
+    links_to_entry({Entries, []}, entry_id)
+  end
+
+  def links_to_entry(queryable, _entry_id) do
+    queryable
+  end
+
+  @doc """
   will __resolve__ a query chain by eagerly calling the API and resolving the response immediately
 
   ## Examples

--- a/lib/contentful/request.ex
+++ b/lib/contentful/request.ex
@@ -51,7 +51,7 @@ defmodule Contentful.Request do
       |> deconstruct_filters()
 
     options
-    |> Keyword.take([:limit, :skip, :include, :content_type, :query])
+    |> Keyword.take([:limit, :skip, :include, :content_type, :query, :links_to_entry])
     |> Keyword.merge(filters)
   end
 


### PR DESCRIPTION
Add support for links_to_entry query parameter

This PR adds support for the `links_to_entry` query parameter to filter entries by the entries they link to in Contentful queries.

**Changes:**
- Added `links_to_entry/2` function to `Contentful.Query` module with proper documentation and examples
- Updated `Contentful.Request` module to include `:links_to_entry` in the list of accepted query parameters

**Usage:**
```elixir
alias Contentful.Delivery.Entries

Entries 
|> links_to_entry("foobar") 
|> fetch_all